### PR TITLE
Feature/read receipts

### DIFF
--- a/backend/models/messageModel.js
+++ b/backend/models/messageModel.js
@@ -13,6 +13,15 @@ const messageModel= mongoose.Schema({
         type:mongoose.Schema.Types.ObjectId,
         ref:"Chats"
     },
+    status: {
+        type: String,
+        enum: ['sending', 'delivered', 'read', 'received'],
+        default: 'sending'
+    },
+    readByReceiver: {
+        type: Boolean,
+        default: false 
+    }
 },
 {
     timestamps:true

--- a/backend/routes/messageRoutes.js
+++ b/backend/routes/messageRoutes.js
@@ -1,9 +1,11 @@
 const express=require("express")
 const { protect } = require("../middleware/authMiddleware")
-const { sendMessage, allMessages } = require("../controllers/messageController")
+const { sendMessage, allMessages, markMessageAsRead, markMessageAsReceived } = require("../controllers/messageController")
 const router=express.Router()
 
 router.route('/').post(protect,sendMessage)
 router.route('/:chatId').get(protect,allMessages)
+router.route('/read').put(protect,markMessageAsRead)
+router.route('/received').put(protect,markMessageAsReceived)
 
 module.exports=router

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,10 +19,12 @@
         "framer-motion": "^10.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^5.3.0",
         "react-lottie": "^1.2.4",
+        "react-notification-badge": "^1.5.1",
         "react-router-dom": "^6.9.0",
         "react-scripts": "5.0.1",
-        "react-scrollable-feed": "^2.0.1",
+        "react-scrollable-feed": "^2.0.2",
         "react-toastify": "^10.0.5",
         "socket.io-client": "^4.6.1",
         "web-vitals": "^2.1.4"
@@ -5058,104 +5060,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
-      }
-    },
-    "node_modules/@testing-library/dom": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
-      "integrity": "sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-      "peer": true,
-      "dependencies": {
-        "deep-equal": "^2.0.5"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@testing-library/dom/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@testing-library/jest-dom": {
@@ -16603,6 +16507,14 @@
         }
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -16621,6 +16533,19 @@
       },
       "peerDependencies": {
         "react": ">=15.0.0"
+      }
+    },
+    "node_modules/react-notification-badge": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/react-notification-badge/-/react-notification-badge-1.5.1.tgz",
+      "integrity": "sha512-4/kFrQcJ7eMfYh9SdXXgBaaEDCIV7UsLX5bgSS1aj+OnX2OpIFTatY3Dclo8qLpkX+Ue6x0Aiib+U9dkDKrSwQ==",
+      "dependencies": {
+        "core-js": "3"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.7.2",
+        "react": "^16.8.6",
+        "react-dom": "^16.8.6"
       }
     },
     "node_modules/react-refresh": {
@@ -16779,9 +16704,9 @@
       }
     },
     "node_modules/react-scrollable-feed": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/react-scrollable-feed/-/react-scrollable-feed-2.0.1.tgz",
-      "integrity": "sha512-cCcR47TPpjI6tZELchddGlvBQT3CQT2AyMfhRCHS4TFrEHEVH90Yj6Nxg43LXqXO2YVzNIDtbRckYFl0t4hgdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-scrollable-feed/-/react-scrollable-feed-2.0.2.tgz",
+      "integrity": "sha512-G00Wab4hxKJ6IP/FnYHOHz2pwNPG/LyrbqusUXHtn3yNW/owAGx+hMfQMnH6b4yXS+pH8kNKCDG0TVNSGBGFbQ==",
       "peerDependencies": {
         "prop-types": "^15.7.2",
         "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
@@ -18832,19 +18757,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -20558,8 +20470,7 @@
     "@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "requires": {}
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w=="
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -21576,8 +21487,7 @@
     "@chakra-ui/control-box": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-2.0.13.tgz",
-      "integrity": "sha512-FEyrU4crxati80KUF/+1Z1CU3eZK6Sa0Yv7Z/ydtz9/tvGblXW9NFanoomXAOvcIFLbaLQPPATm9Gmpr7VG05A==",
-      "requires": {}
+      "integrity": "sha512-FEyrU4crxati80KUF/+1Z1CU3eZK6Sa0Yv7Z/ydtz9/tvGblXW9NFanoomXAOvcIFLbaLQPPATm9Gmpr7VG05A=="
     },
     "@chakra-ui/counter": {
       "version": "2.0.14",
@@ -21592,8 +21502,7 @@
     "@chakra-ui/css-reset": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-2.0.12.tgz",
-      "integrity": "sha512-Q5OYIMvqTl2vZ947kIYxcS5DhQXeStB84BzzBd6C10wOx1gFUu9pL+jLpOnHR3hhpWRMdX5o7eT+gMJWIYUZ0Q==",
-      "requires": {}
+      "integrity": "sha512-Q5OYIMvqTl2vZ947kIYxcS5DhQXeStB84BzzBd6C10wOx1gFUu9pL+jLpOnHR3hhpWRMdX5o7eT+gMJWIYUZ0Q=="
     },
     "@chakra-ui/descendant": {
       "version": "3.0.13",
@@ -21768,8 +21677,7 @@
     "@chakra-ui/live-region": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-2.0.13.tgz",
-      "integrity": "sha512-Ja+Slk6ZkxSA5oJzU2VuGU7TpZpbMb/4P4OUhIf2D30ctmIeXkxTWw1Bs1nGJAVtAPcGS5sKA+zb89i8g+0cTQ==",
-      "requires": {}
+      "integrity": "sha512-Ja+Slk6ZkxSA5oJzU2VuGU7TpZpbMb/4P4OUhIf2D30ctmIeXkxTWw1Bs1nGJAVtAPcGS5sKA+zb89i8g+0cTQ=="
     },
     "@chakra-ui/media-query": {
       "version": "3.2.12",
@@ -21993,14 +21901,12 @@
     "@chakra-ui/react-children-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-children-utils/-/react-children-utils-2.0.6.tgz",
-      "integrity": "sha512-QVR2RC7QsOsbWwEnq9YduhpqSFnZGvjjGREV8ygKi8ADhXh93C8azLECCUVgRJF2Wc+So1fgxmjLcbZfY2VmBA==",
-      "requires": {}
+      "integrity": "sha512-QVR2RC7QsOsbWwEnq9YduhpqSFnZGvjjGREV8ygKi8ADhXh93C8azLECCUVgRJF2Wc+So1fgxmjLcbZfY2VmBA=="
     },
     "@chakra-ui/react-context": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-context/-/react-context-2.0.7.tgz",
-      "integrity": "sha512-i7EGmSU+h2GB30cwrKB4t1R5BMHyGoJM5L2Zz7b+ZUX4aAqyPcfe97wPiQB6Rgr1ImGXrUeov4CDVrRZ2FPgLQ==",
-      "requires": {}
+      "integrity": "sha512-i7EGmSU+h2GB30cwrKB4t1R5BMHyGoJM5L2Zz7b+ZUX4aAqyPcfe97wPiQB6Rgr1ImGXrUeov4CDVrRZ2FPgLQ=="
     },
     "@chakra-ui/react-env": {
       "version": "3.0.0",
@@ -22013,8 +21919,7 @@
     "@chakra-ui/react-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-types/-/react-types-2.0.7.tgz",
-      "integrity": "sha512-12zv2qIZ8EHwiytggtGvo4iLT0APris7T0qaAWqzpUGS0cdUtR8W+V1BJ5Ocq+7tA6dzQ/7+w5hmXih61TuhWQ==",
-      "requires": {}
+      "integrity": "sha512-12zv2qIZ8EHwiytggtGvo4iLT0APris7T0qaAWqzpUGS0cdUtR8W+V1BJ5Ocq+7tA6dzQ/7+w5hmXih61TuhWQ=="
     },
     "@chakra-ui/react-use-animation-state": {
       "version": "2.0.8",
@@ -22028,8 +21933,7 @@
     "@chakra-ui/react-use-callback-ref": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-callback-ref/-/react-use-callback-ref-2.0.7.tgz",
-      "integrity": "sha512-YjT76nTpfHAK5NxplAlZsQwNju5KmQExnqsWNPFeOR6vvbC34+iPSTr+r91i1Hdy7gBSbevsOsd5Wm6RN3GuMw==",
-      "requires": {}
+      "integrity": "sha512-YjT76nTpfHAK5NxplAlZsQwNju5KmQExnqsWNPFeOR6vvbC34+iPSTr+r91i1Hdy7gBSbevsOsd5Wm6RN3GuMw=="
     },
     "@chakra-ui/react-use-controllable-state": {
       "version": "2.0.8",
@@ -22085,14 +21989,12 @@
     "@chakra-ui/react-use-latest-ref": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-latest-ref/-/react-use-latest-ref-2.0.5.tgz",
-      "integrity": "sha512-3mIuFzMyIo3Ok/D8uhV9voVg7KkrYVO/pwVvNPJOHsDQqCA6DpYE4WDsrIx+fVcwad3Ta7SupexR5PoI+kq6QQ==",
-      "requires": {}
+      "integrity": "sha512-3mIuFzMyIo3Ok/D8uhV9voVg7KkrYVO/pwVvNPJOHsDQqCA6DpYE4WDsrIx+fVcwad3Ta7SupexR5PoI+kq6QQ=="
     },
     "@chakra-ui/react-use-merge-refs": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-merge-refs/-/react-use-merge-refs-2.0.7.tgz",
-      "integrity": "sha512-zds4Uhsc+AMzdH8JDDkLVet9baUBgtOjPbhC5r3A0ZXjZvGhCztFAVE3aExYiVoMPoHLKbLcqvCWE6ioFKz1lw==",
-      "requires": {}
+      "integrity": "sha512-zds4Uhsc+AMzdH8JDDkLVet9baUBgtOjPbhC5r3A0ZXjZvGhCztFAVE3aExYiVoMPoHLKbLcqvCWE6ioFKz1lw=="
     },
     "@chakra-ui/react-use-outside-click": {
       "version": "2.0.7",
@@ -22115,14 +22017,12 @@
     "@chakra-ui/react-use-previous": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-previous/-/react-use-previous-2.0.5.tgz",
-      "integrity": "sha512-BIZgjycPE4Xr+MkhKe0h67uHXzQQkBX/u5rYPd65iMGdX1bCkbE0oorZNfOHLKdTmnEb4oVsNvfN6Rfr+Mnbxw==",
-      "requires": {}
+      "integrity": "sha512-BIZgjycPE4Xr+MkhKe0h67uHXzQQkBX/u5rYPd65iMGdX1bCkbE0oorZNfOHLKdTmnEb4oVsNvfN6Rfr+Mnbxw=="
     },
     "@chakra-ui/react-use-safe-layout-effect": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-safe-layout-effect/-/react-use-safe-layout-effect-2.0.5.tgz",
-      "integrity": "sha512-MwAQBz3VxoeFLaesaSEN87reVNVbjcQBDex2WGexAg6hUB6n4gc1OWYH/iXp4tzp4kuggBNhEHkk9BMYXWfhJQ==",
-      "requires": {}
+      "integrity": "sha512-MwAQBz3VxoeFLaesaSEN87reVNVbjcQBDex2WGexAg6hUB6n4gc1OWYH/iXp4tzp4kuggBNhEHkk9BMYXWfhJQ=="
     },
     "@chakra-ui/react-use-size": {
       "version": "2.0.9",
@@ -22143,8 +22043,7 @@
     "@chakra-ui/react-use-update-effect": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-update-effect/-/react-use-update-effect-2.0.7.tgz",
-      "integrity": "sha512-vBM2bmmM83ZdDtasWv3PXPznpTUd+FvqBC8J8rxoRmvdMEfrxTiQRBJhiGHLpS9BPLLPQlosN6KdFU97csB6zg==",
-      "requires": {}
+      "integrity": "sha512-vBM2bmmM83ZdDtasWv3PXPznpTUd+FvqBC8J8rxoRmvdMEfrxTiQRBJhiGHLpS9BPLLPQlosN6KdFU97csB6zg=="
     },
     "@chakra-ui/react-utils": {
       "version": "2.0.12",
@@ -22372,8 +22271,7 @@
     "@chakra-ui/visually-hidden": {
       "version": "2.0.15",
       "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-2.0.15.tgz",
-      "integrity": "sha512-WWULIiucYRBIewHKFA7BssQ2ABLHLVd9lrUo3N3SZgR0u4ZRDDVEUNOy+r+9ruDze8+36dGbN9wsN1IdELtdOw==",
-      "requires": {}
+      "integrity": "sha512-WWULIiucYRBIewHKFA7BssQ2ABLHLVd9lrUo3N3SZgR0u4ZRDDVEUNOy+r+9ruDze8+36dGbN9wsN1IdELtdOw=="
     },
     "@csstools/normalize.css": {
       "version": "12.0.0",
@@ -22492,14 +22390,12 @@
     "@csstools/postcss-unset-value": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-1.0.2.tgz",
-      "integrity": "sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g==",
-      "requires": {}
+      "integrity": "sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g=="
     },
     "@csstools/selector-specificity": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
-      "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
-      "requires": {}
+      "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw=="
     },
     "@emotion/babel-plugin": {
       "version": "11.11.0",
@@ -22619,8 +22515,7 @@
     "@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
-      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
-      "requires": {}
+      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw=="
     },
     "@emotion/utils": {
       "version": "1.2.1",
@@ -23598,82 +23493,6 @@
         "@svgr/plugin-jsx": "^5.5.0",
         "@svgr/plugin-svgo": "^5.5.0",
         "loader-utils": "^2.0.0"
-      }
-    },
-    "@testing-library/dom": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
-      "integrity": "sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==",
-      "peer": true,
-      "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "peer": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "aria-query": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-          "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-          "peer": true,
-          "requires": {
-            "deep-equal": "^2.0.5"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "peer": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "peer": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "peer": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "peer": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "@testing-library/jest-dom": {
@@ -24682,14 +24501,12 @@
     "acorn-import-assertions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "requires": {}
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "requires": {}
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -24758,8 +24575,7 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "requires": {}
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -25138,8 +24954,7 @@
     "babel-plugin-named-asset-import": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
-      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
-      "requires": {}
+      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q=="
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.4.7",
@@ -25796,8 +25611,7 @@
     "css-declaration-sorter": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
-      "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
-      "requires": {}
+      "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g=="
     },
     "css-has-pseudo": {
       "version": "3.0.4",
@@ -25880,8 +25694,7 @@
     "css-prefers-color-scheme": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
-      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
-      "requires": {}
+      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA=="
     },
     "css-select": {
       "version": "4.3.0",
@@ -25985,8 +25798,7 @@
     "cssnano-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "requires": {}
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA=="
     },
     "csso": {
       "version": "4.2.0",
@@ -26389,8 +26201,7 @@
         "ws": {
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-          "requires": {}
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg=="
         }
       }
     },
@@ -26902,8 +26713,7 @@
     "eslint-plugin-react-hooks": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "requires": {}
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g=="
     },
     "eslint-plugin-testing-library": {
       "version": "5.11.1",
@@ -28002,8 +27812,7 @@
     "icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "requires": {}
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
     },
     "idb": {
       "version": "7.1.1",
@@ -29152,8 +28961,7 @@
     "jest-pnp-resolver": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
-      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "requires": {}
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w=="
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -30913,8 +30721,7 @@
     "postcss-browser-comments": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-4.0.0.tgz",
-      "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==",
-      "requires": {}
+      "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg=="
     },
     "postcss-calc": {
       "version": "8.2.4",
@@ -31012,26 +30819,22 @@
     "postcss-discard-comments": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
-      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
-      "requires": {}
+      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ=="
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "requires": {}
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw=="
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-      "requires": {}
+      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A=="
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "requires": {}
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw=="
     },
     "postcss-double-position-gradients": {
       "version": "3.1.2",
@@ -31053,8 +30856,7 @@
     "postcss-flexbugs-fixes": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
-      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
-      "requires": {}
+      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ=="
     },
     "postcss-focus-visible": {
       "version": "6.0.4",
@@ -31075,14 +30877,12 @@
     "postcss-font-variant": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-      "requires": {}
+      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA=="
     },
     "postcss-gap-properties": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.5.tgz",
-      "integrity": "sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg==",
-      "requires": {}
+      "integrity": "sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg=="
     },
     "postcss-image-set-function": {
       "version": "4.0.7",
@@ -31105,8 +30905,7 @@
     "postcss-initial": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-      "requires": {}
+      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ=="
     },
     "postcss-js": {
       "version": "4.0.1",
@@ -31159,14 +30958,12 @@
     "postcss-logical": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
-      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
-      "requires": {}
+      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g=="
     },
     "postcss-media-minmax": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
-      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-      "requires": {}
+      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ=="
     },
     "postcss-merge-longhand": {
       "version": "5.1.7",
@@ -31227,8 +31024,7 @@
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "requires": {}
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.3",
@@ -31286,8 +31082,7 @@
     "postcss-normalize-charset": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "requires": {}
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg=="
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -31358,8 +31153,7 @@
     "postcss-opacity-percentage": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.3.tgz",
-      "integrity": "sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A==",
-      "requires": {}
+      "integrity": "sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A=="
     },
     "postcss-ordered-values": {
       "version": "5.1.3",
@@ -31381,8 +31175,7 @@
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-      "requires": {}
+      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ=="
     },
     "postcss-place": {
       "version": "7.0.5",
@@ -31476,8 +31269,7 @@
     "postcss-replace-overflow-wrap": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
-      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-      "requires": {}
+      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw=="
     },
     "postcss-selector-not": {
       "version": "6.0.1",
@@ -31888,6 +31680,11 @@
         "use-sidecar": "^1.1.2"
       }
     },
+    "react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg=="
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -31900,6 +31697,14 @@
       "requires": {
         "babel-runtime": "^6.26.0",
         "lottie-web": "^5.1.3"
+      }
+    },
+    "react-notification-badge": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/react-notification-badge/-/react-notification-badge-1.5.1.tgz",
+      "integrity": "sha512-4/kFrQcJ7eMfYh9SdXXgBaaEDCIV7UsLX5bgSS1aj+OnX2OpIFTatY3Dclo8qLpkX+Ue6x0Aiib+U9dkDKrSwQ==",
+      "requires": {
+        "core-js": "3"
       }
     },
     "react-refresh": {
@@ -32001,10 +31806,9 @@
       }
     },
     "react-scrollable-feed": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/react-scrollable-feed/-/react-scrollable-feed-2.0.1.tgz",
-      "integrity": "sha512-cCcR47TPpjI6tZELchddGlvBQT3CQT2AyMfhRCHS4TFrEHEVH90Yj6Nxg43LXqXO2YVzNIDtbRckYFl0t4hgdQ==",
-      "requires": {}
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-scrollable-feed/-/react-scrollable-feed-2.0.2.tgz",
+      "integrity": "sha512-G00Wab4hxKJ6IP/FnYHOHz2pwNPG/LyrbqusUXHtn3yNW/owAGx+hMfQMnH6b4yXS+pH8kNKCDG0TVNSGBGFbQ=="
     },
     "react-style-singleton": {
       "version": "2.2.1",
@@ -32999,8 +32803,7 @@
     "style-loader": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.3.tgz",
-      "integrity": "sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==",
-      "requires": {}
+      "integrity": "sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw=="
     },
     "stylehacks": {
       "version": "5.1.1",
@@ -33513,12 +33316,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "peer": true
-    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -33910,8 +33707,7 @@
         "ws": {
           "version": "8.16.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-          "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
-          "requires": {}
+          "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ=="
         }
       }
     },
@@ -34420,8 +34216,7 @@
     "ws": {
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "requires": {}
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,10 +15,12 @@
     "framer-motion": "^10.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.3.0",
     "react-lottie": "^1.2.4",
+    "react-notification-badge": "^1.5.1",
     "react-router-dom": "^6.9.0",
     "react-scripts": "5.0.1",
-    "react-scrollable-feed": "^2.0.1",
+    "react-scrollable-feed": "^2.0.2",
     "react-toastify": "^10.0.5",
     "socket.io-client": "^4.6.1",
     "web-vitals": "^2.1.4"

--- a/frontend/src/components/ScrollableChat.js
+++ b/frontend/src/components/ScrollableChat.js
@@ -2,43 +2,94 @@ import React from 'react'
 import { ChatState } from '../context/ChatProvider'
 import ScrollableFeed from 'react-scrollable-feed'
 import { isLastMessage, isSameSender, isSameSenderMargin,isSameUser } from '../config/ChatLogics'
-import { Avatar, Tooltip } from '@chakra-ui/react'
+import { Avatar, Tooltip, Box, Text, Icon } from '@chakra-ui/react'
+import { BiCheck, BiCheckDouble } from "react-icons/bi";
+import { CiClock2 } from "react-icons/ci";
 
 const ScrollableChat = ({messages}) => {
   const {user}=ChatState()
 
   return (
     <ScrollableFeed>
-      {messages&&messages.map((m,i)=>(
-        <div style={{display:"flex"}} key = {m._id}>
-          {(isSameSender(messages,m,i,user._id)||
-          isLastMessage(messages,i,user._id))&&(
+      {messages && messages.map((m, i) => (
+        <Box display="flex" key={m._id}>
+          {(isSameSender(messages, m, i, user._id) ||
+            isLastMessage(messages, i, user._id)) && (
             <Tooltip label={m.sender.name} placement="bottom-start" hasArrow>
               <Avatar
-                        mt="7px"
-                        mr={1}
-                        size="sm"
-                        cursor="pointer"
-                        name={m.sender.name}
-                        src={m.sender.profilePic}
-                        />
+                mt="7px"
+                mr={1}
+                size="sm"
+                cursor="pointer"
+                name={m.sender.name}
+                src={m.sender.profilePic}
+              />
             </Tooltip>
           )}
-          <span style={{
-                    backgroundColor:`${
-                        m.sender._id === user._id ? "#BEE3F8" : "#B9F5D0" 
-                    }`,
-                    borderRadius:"20px",
-                    padding:"5px 15px",
-                    maxWidth:"75%",
-                    marginLeft:isSameSenderMargin(messages,m,i,user._id),
-                    marginTop:isSameUser(messages,m,i,user._id) ? 3 : 10,
-                }}>
-                    {m.content}
-                </span>
-        </div>
+          <Box
+            bg={m.sender._id === user._id ? "#BEE3F8" : "#B9F5D0"}
+            borderRadius="17px"
+            p="7px 17px"
+            maxWidth="75%"
+            ml={isSameSenderMargin(messages, m, i, user._id)}
+            mt={isSameUser(messages, m, i, user._id) ? 3 : 10}
+            position="relative" // To position the icon
+          >
+            <Text>{m.content}</Text>
+
+            {m.sender._id === user._id && ( 
+              <>
+              {/* Sending to the server -> clock */}
+              {m.status === 'sending' &&(
+                <Icon
+                  as={CiClock2}
+                  position="absolute"
+                  bottom="3px" 
+                  right="5px" 
+                  boxSize="11px" 
+                  color="#012E1F" 
+                />
+              )}
+              {/* Sent to he server -> single gray tick */}
+              {m.status === 'delivered' &&(
+                <Icon
+                  as={BiCheck}
+                  position="absolute"
+                  bottom="3px" 
+                  right="5px" 
+                  boxSize="15px" 
+                  color="gray.500" 
+                />
+              )}
+              {/* received but not read -> double gray tick */}
+              {m.status === 'received' &&(
+                <Icon
+                  as={BiCheckDouble}
+                  position="absolute"
+                  bottom="3px" 
+                  right="5px" 
+                  boxSize="15px" 
+                  color="gray.500" 
+                />
+              )}
+              {/* received and read -> double green tick */}
+              {m.readByReceiver && (
+                <Icon
+                  as={BiCheckDouble}
+                  position="absolute"
+                  bottom="3px" 
+                  right="5px" 
+                  boxSize="15px" 
+                  color="green.500" 
+                />
+              )}
+
+              </>
+            )}
+          </Box>
+        </Box>
       ))}
- </ScrollableFeed>
+    </ScrollableFeed>
   )
 }
 

--- a/frontend/src/components/SingleChat.js
+++ b/frontend/src/components/SingleChat.js
@@ -80,7 +80,7 @@ const SingleChat = ({fetchAgain,setFetchAgain}) => {
     useEffect(() => {
       socket.on("message recieved", (newMessageRecieved) => {
         if (!selectedChatCompare || selectedChatCompare._id !== newMessageRecieved.chat._id) {
-          markMessageAsReceived(newMessageRecieved.chat._id); 
+          // markMessageAsReceived(newMessageRecieved.chat._id); 
           // Give notification if not in the current chat
           if (!notification.includes(newMessageRecieved)) {
             setNotification([newMessageRecieved, ...notification]);
@@ -173,7 +173,7 @@ const SingleChat = ({fetchAgain,setFetchAgain}) => {
       return () => {
         socket.off('messages received update');
       };
-    }, [notification]);
+    }, [selectedChatCompare,notification]);
 
 
     console.log(notification,"------------>")

--- a/frontend/src/components/SingleChat.js
+++ b/frontend/src/components/SingleChat.js
@@ -51,6 +51,7 @@ const SingleChat = ({fetchAgain,setFetchAgain}) => {
 
         // Mark the fetched messages as read
         markMessagesAsRead(data);
+
       } catch (error) {
         toast({
         title: "Error Occured!",
@@ -83,22 +84,20 @@ const SingleChat = ({fetchAgain,setFetchAgain}) => {
           // Give notification if not in the current chat
           if (!notification.includes(newMessageRecieved)) {
             setNotification([newMessageRecieved, ...notification]);
-            markMessageAsReceived(newMessageRecieved.chat._id); 
-            console.log('notif gyi!!!')
             setFetchAgain(!fetchAgain);
+            markMessageAsReceived(newMessageRecieved.chat._id); 
           }
         } else {
           // If in the current chat, add the message to messages and mark it as read
           setMessages([...messages, newMessageRecieved]);
           
           // Emit an event to mark the message as read in the backend
-          // markMessagesAsRead(newMessageRecieved.chat._id); 
+          markMessagesAsRead(newMessageRecieved.chat._id); 
         }
       });
     }, [messages, selectedChatCompare, notification]);
     
     const markMessageAsReceived = async () => {
-      // console.log('call hua');
       try {
         const config = {
           headers: {
@@ -156,15 +155,14 @@ const SingleChat = ({fetchAgain,setFetchAgain}) => {
       return () => {
         socket.off('messages updated');
       };
-    }, [selectedChatCompare]);
+    }, []);
 
 
     // to mark the message as received at the sender side:
     useEffect(() => {
       socket.on('messages received update', (data) => {
-        console.log("Challllaaa bhaiii !!!2")
 
-        if (selectedChatCompare._id === data.chatId) {
+        if (selectedChatCompare._id === data.chatId || notification) {
           // Mark all messages in the current chat as "received"
           setMessages((prevMessages) =>
             prevMessages.map((m) => ({ ...m, status: 'received' }))
@@ -175,7 +173,7 @@ const SingleChat = ({fetchAgain,setFetchAgain}) => {
       return () => {
         socket.off('messages received update');
       };
-    }, [selectedChatCompare,fetchAgain]);
+    }, [notification]);
 
 
     console.log(notification,"------------>")

--- a/frontend/src/components/miscellaneous/GroupChatModal.js
+++ b/frontend/src/components/miscellaneous/GroupChatModal.js
@@ -56,7 +56,7 @@ const GroupChatModal = ({children}) => {
           Authorization: `Bearer ${user.token}`,
         },
             }
-            const {data}=await axios.get(`/api/user?search=${search}`,config)
+            const {data}=await axios.get(`/api/user/register?search=${search}`,config)
             //console.log(data)
             setLoading(false)
             setSearchResult(data)

--- a/frontend/src/components/miscellaneous/SideDrawer.js
+++ b/frontend/src/components/miscellaneous/SideDrawer.js
@@ -10,6 +10,8 @@ import { useToast } from '@chakra-ui/react'
 import { getSender } from '../../config/ChatLogics.js';
 import ChatLoading from "../ChatLoading";
 // import {Spinner} from "@chakra-ui/spinner"
+import NotificationBadge from "react-notification-badge";
+import { Effect } from "react-notification-badge";
 import { useNavigate } from 'react-router-dom'
 import {
   Drawer,
@@ -113,6 +115,10 @@ const SideDrawer = () => {
         <div>
           <Menu>
             <MenuButton p={1}>
+            <NotificationBadge
+            count={notification.length}
+            effect={Effect.SCALE}
+            />
               <BellIcon fontSize="2xl" m={1}/>
             </MenuButton>
             <MenuList pl={2}>

--- a/frontend/src/components/miscellaneous/SideDrawer.js
+++ b/frontend/src/components/miscellaneous/SideDrawer.js
@@ -57,7 +57,7 @@ const SideDrawer = () => {
           },
         }
 
-        const {data}=await axios.get(`/api/user?search=${search}`,config)
+        const {data}=await axios.get(`/api/user/register?search=${search}`,config)
         //a GET request to an endpoint (/api/user) with a query parameter search, which likely contains the search term.
         setLoading(false)
         setSearchResults(data)


### PR DESCRIPTION
# Added Sent, Received, Read receipts
Issue: #1 

## Description
1) When a receiver sends a message and is succesfully delivered to the server a single tick is displayed in the message as acknowledgement:
![Screenshot 2024-10-10 212002](https://github.com/user-attachments/assets/a4f5f71b-acaa-4d06-a5f3-8b23fce09188)

2) When the message is received by receiver from the server but not read, it is acknowledged by a double tick in the message:
![Screenshot 2024-10-10 213425](https://github.com/user-attachments/assets/68a741e7-49da-4383-a964-511a7216147b)

3.) When the message received is read by the reciever, it is acknowledged by a green double tick: 
![Screenshot 2024-10-10 213644](https://github.com/user-attachments/assets/2e888f3c-fb3d-48ca-9c0b-3cb8030dcfb3)

## Related Issue
While setting up the project, I noticed the api request from the frontend to search users in the side drawer and create gorup chat section was /api/user/ only instead of /api/user/register, so I fixed it by replacing it with the correct api request as already created in the backend.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Motivation and Context

To give a visual acknowledgement to the sender whethere the message has been sent, received and read by the server or the receiver.

## Screenrecording:

https://github.com/user-attachments/assets/e68656cd-f1d3-4f27-b13f-567d2e918df1



## Checklist:
- [x] I have registered myself at [Contrihub website](https://sac.mnnit.ac.in/contrihub).
- [x] My code follows the code style of this project.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
